### PR TITLE
Update edge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,13 +55,11 @@ jobs:
       python: 3.7
       deploy:
         provider: pypi
+        edge: true
         user: rossum
         password: ${PYPI_DEPLOY_PASSWORD}
         on:
           tags: true
-        edge:
-          source: 'native-api/dpl'
-          branch: 'pip_fix_upgrade_deps'
 
 
 install:


### PR DESCRIPTION
This update is to allow us to deploy to pypi although the [Travis deployment issue ](https://travis-ci.community/t/cant-deploy-to-pypi-anymore-pkg-resources-contextualversionconflict-importlib-metadata-0-18/10494/23)persists.