### PR TITLE
Retry the request to get a correct Rossum response

### DIFF
--- a/rossum/lib/api_client.py
+++ b/rossum/lib/api_client.py
@@ -55,6 +55,23 @@ class APIClient(AbstractContextManager):
         max_token_lifetime: Optional[int] = None,
         retry_logic_rules: Optional[Dict] = None,
     ):
+        """The APIClient for communication with Rossum API.
+
+        :param context Used for switching profile. Send None for usual requests done for your default profile.
+        :param url Rossum API URL. Leave None for communication with the currently used publicly available Rossum API.
+        :param user Your username.
+        :param password Your password.
+        :param use_api_version Leave True if you want to use the latest API version. If set to false,
+        specify the Rossum API URL including its version in the url parameter explicitly.
+        :param auth_using_token To avoid using login request for each call, leave set to True.
+        :param max_token_lifetime Set custom max token lifetime in seconds. Default is the maximum lifetime: 583200s
+        or until the Rossum client logs out. Logging out is made when CLI is exited or if RossumClient() is used
+        with a with statement.
+        :param retry_logic_rules Pass logic rules for built-in retry mechanism that is called when it is currently
+        not possible to communicate with Rossum API. The default shape of the dictionary is:
+        {"attempts": 3, "wait_s": 5}. "attempts" key states the number of retry attempts. "wait_s" is time in seconds
+        the APIClient will wait before retrying again.
+        """
         self._url = url
         self._user = user
         self._password = password

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         "jmespath",
         "polling2",
         "more_itertools",
+        "tenacity",
     ],
     python_requires=">=3.6",
     setup_requires=["pytest-runner"],


### PR DESCRIPTION
Rossum API sometimes responds with 502, 503 or 504 error codes. Such state in Rossum can take a few microseconds to lower seconds. Therefore, applying a retry mechanism for successfully passing a request if these errors occur to make up for these errors makes sense.

This MR applies the retry logic to all requests done within the library. It sets the default rules to apply the retry logic 3 times max, while waiting 5 seconds after each request and max. 55 seconds (because a request to Rossum automatically times out after 60 seconds anyway). The chosen exceptions are those that happen based on real life situations. Also, docstrings are added to the `APIClient()` to provide hints for the users on how to set up (not only) the retry logic rules.