### PR TITLE
RossumClient.get_queues(): Allow retrieving many queues by a set of ids

### DIFF
--- a/rossum/lib/api_client.py
+++ b/rossum/lib/api_client.py
@@ -317,11 +317,14 @@ class RossumClient(APIClient):
         self,
         sideloads: Optional[Iterable[APIObject]] = None,
         *,
+        any_of_ids: Optional[Iterable[int]] = None,
         workspace: Optional[int] = None,
         users: Optional[Iterable[int]] = None,
         hooks: Optional[Iterable[int]] = None,
     ) -> List[dict]:
         query: Dict[str, Any] = {}
+        if any_of_ids:
+            query["id"] = ",".join(str(qid) for qid in any_of_ids)
         if workspace:
             query[WORKSPACES.singular] = workspace
         if users:


### PR DESCRIPTION
    Allow retrieving many queues at once by a set of ids.

    The rationale of naming this 'ids_any' is to distinguish the OR behavior
    in this case from the other attributes who behave like AND.