### PR TITLE
Add tenacity library to installer.cfg

### DIFF
--- a/installer.cfg
+++ b/installer.cfg
@@ -11,19 +11,20 @@ bitness=64
 [Include]
 pypi_wheels = certifi==2019.6.16
     chardet==3.0.4
-    Click==7.0
-    click-shell==1.0
+    Click==7.1.2
+    click-shell==2.0
     idna==2.8
     jdcal==1.4.1
-    jmespath==0.9.4
-    numpy==1.16.4
-    pandas==0.24.2
+    jmespath==0.10.0
+    numpy==1.20.0
+    pandas==1.2.4
     polling2==0.4.3
     python-dateutil==2.8.0
     pytz==2019.1
-    requests==2.22.0
+    requests==2.25.0
     six==1.12.0
-    urllib3==1.25.3
+    tenacity==7.0.0
+    urllib3==1.26.4
     xlrd==1.2.0
 packages = tabulate
     jsondiff

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     packages=find_packages(exclude=("tests*",)),
     install_requires=[
         "pandas",
-        "click",
+        "click<=7.1.2",
         "click-shell",
         'xlrd > 1.2.0;python_version>"3.6"',
         'xlrd==1.2.0;python_version=="3.6"',


### PR DESCRIPTION
To [avoid Windows build from failing](https://github.com/rossumai/rossum/issues/26). While fixing this issue, other libraries are updated as well. `click` library must be pinned due to incompatibilities issues connected with the latest bump to `8.0.0` version (waiting for the fix).