### PR TITLE
Allow creating inbox without bounce email

### DIFF
--- a/rossum/lib/api_client.py
+++ b/rossum/lib/api_client.py
@@ -456,25 +456,27 @@ class RossumClient(APIClient):
         return get_json(self.post("queues", data))
 
     def create_inbox(
-        self, name: str, email_prefix: Optional[str], bounce_email: Optional[str], queue_url: str
+        self,
+        name: str,
+        email_prefix: Optional[str],
+        bounce_email: Optional[str],
+        queue_url: str,
+        email: Optional[str] = None,
     ) -> dict:
-        if not (email_prefix and bounce_email):
+        if not (email_prefix or email):
             raise RossumException(
-                "Inbox cannot be created without both bounce email and email prefix specified."
+                "Inbox cannot be created without email prefix or email specified."
             )
-
-        return get_json(
-            self.post(
-                "inboxes",
-                data={
-                    "name": name,
-                    "email_prefix": email_prefix,
-                    "bounce_email_to": bounce_email,
-                    "bounce_unprocessable_attachments": True,
-                    "queues": [queue_url],
-                },
-            )
-        )
+        inbox_creation_data = {
+            "name": name,
+            "email_prefix": email_prefix,
+            "bounce_email_to": bounce_email,
+            "bounce_unprocessable_attachments": True if bounce_email else False,
+            "queues": [queue_url],
+        }
+        if email:
+            inbox_creation_data["email"] = email
+        return get_json(self.post("inboxes", data=inbox_creation_data))
 
     def create_user(
         self,

--- a/rossum/queue.py
+++ b/rossum/queue.py
@@ -39,9 +39,6 @@ def create_command(
     hook_id: Optional[Tuple[int, ...]],
     locale: Optional[str],
 ) -> None:
-    if email_prefix is not None and bounce_email is None:
-        raise click.ClickException("Inbox cannot be created without specified bounce email.")
-
     with RossumClient(context=ctx.obj) as rossum:
         workspace_url = rossum.get_workspace(workspace_id)["url"]
         connector_url = (
@@ -131,7 +128,7 @@ def change_command(
     locale: Optional[str],
 ) -> None:
 
-    if not any([name, schema_content, email_prefix, bounce_email, connector_id, locale, hook_id]):
+    if not any([name, schema_content, email_prefix, connector_id, locale, hook_id]):
         return
 
     data: Dict[str, Any] = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,6 +97,7 @@ def mock_file(tmp_path):
 
 
 def match_uploaded_json(uploaded_json: dict, request: Request) -> bool:
+    assert request.json() == uploaded_json
     return request.json() == uploaded_json
 
 

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -2,7 +2,7 @@ from functools import partial
 
 import pytest
 
-from rossum.lib.api_client import RossumClient
+from rossum.lib.api_client import RossumClient, RossumException
 from tests.conftest import INBOXES_URL, match_uploaded_json, QUEUES_URL
 
 
@@ -11,7 +11,7 @@ class TestRossumClient:
     rossum_client = RossumClient(None)
 
     @pytest.mark.usefixtures("mock_login_request")
-    def test_create_inbox(self, requests_mock):
+    def test_create_inbox_with_email_prefix(self, requests_mock):
         queue_url = f"{QUEUES_URL}/1"
         requests_mock.post(
             INBOXES_URL,
@@ -36,3 +36,39 @@ class TestRossumClient:
             email=None,
         )
         assert requests_mock.called
+
+    @pytest.mark.usefixtures("mock_login_request")
+    def test_create_inbox_with_email(self, requests_mock):
+        queue_url = f"{QUEUES_URL}/1"
+        requests_mock.post(
+            INBOXES_URL,
+            additional_matcher=partial(
+                match_uploaded_json,
+                {
+                    "name": "My Email",
+                    "email_prefix": None,
+                    "email": "my_email@my_company.com",
+                    "bounce_email_to": None,
+                    "bounce_unprocessable_attachments": False,
+                    "queues": [queue_url],
+                },
+            ),
+            json={"id": 100200},
+            status_code=201,
+        )
+        self.rossum_client.create_inbox(
+            name="My Email",
+            email_prefix=None,
+            bounce_email=None,
+            queue_url=queue_url,
+            email="my_email@my_company.com",
+        )
+        assert requests_mock.called
+
+    @pytest.mark.usefixtures("mock_login_request")
+    def test_create_inbox_failed(self, requests_mock):
+        queue_url = f"{QUEUES_URL}/1"
+        with pytest.raises(RossumException):
+            self.rossum_client.create_inbox(
+                name="My Email", email_prefix=None, bounce_email=None, queue_url=queue_url, email=""
+            )

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,0 +1,38 @@
+from functools import partial
+
+import pytest
+
+from rossum.lib.api_client import RossumClient
+from tests.conftest import INBOXES_URL, match_uploaded_json, QUEUES_URL
+
+
+@pytest.mark.usefixtures("rossum_credentials")
+class TestRossumClient:
+    rossum_client = RossumClient(None)
+
+    @pytest.mark.usefixtures("mock_login_request")
+    def test_create_inbox(self, requests_mock):
+        queue_url = f"{QUEUES_URL}/1"
+        requests_mock.post(
+            INBOXES_URL,
+            additional_matcher=partial(
+                match_uploaded_json,
+                {
+                    "name": "My Email",
+                    "email_prefix": "my-email-prefix",
+                    "bounce_email_to": None,
+                    "bounce_unprocessable_attachments": False,
+                    "queues": [queue_url],
+                },
+            ),
+            json={"id": 100200},
+            status_code=201,
+        )
+        self.rossum_client.create_inbox(
+            name="My Email",
+            email_prefix="my-email-prefix",
+            bounce_email=None,
+            queue_url=queue_url,
+            email=None,
+        )
+        assert requests_mock.called

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -147,15 +147,6 @@ class TestCreate(QueueFixtures):
         assert not result.exit_code, print_tb(result.exc_info[2])
         assert f"{self.queue_id}, {email}\n" == result.output
 
-    @pytest.mark.usefixtures("create_queue_schema")
-    def test_cannot_create_inbox(self, isolated_cli_runner):
-        result = isolated_cli_runner.invoke(
-            create_command,
-            ["--schema-content-file", SCHEMA_FILE_NAME, "--email-prefix", "1234567", self.name],
-        )
-        assert result.exit_code == 1, print_tb(result.exc_info[2])
-        assert "Error: Inbox cannot be created without specified bounce email.\n" == result.output
-
     @pytest.mark.usefixtures("create_queue_urls", "create_queue_schema")
     def test_create_queue_with_hooks(self, requests_mock, isolated_cli_runner):
         first_hook_id = 101
@@ -422,17 +413,6 @@ class TestChange(QueueFixtures):
         )
         assert not result.exit_code, print_tb(result.exc_info[2])
         assert result.output == f"{self.inbox_id}, {self.inbox_email}, {bounce_mail}\n"
-
-    @pytest.mark.usefixtures("create_queue_urls")
-    def test_cannot_create_inbox_on_queue_change(self, isolated_cli_runner):
-        result = isolated_cli_runner.invoke(
-            change_command, [self.queue_id, "--email-prefix", self.email_prefix]
-        )
-        assert result.exit_code == 1, print_tb(result.exc_info[2])
-        assert (
-            "Error: Inbox cannot be created without both bounce email and email prefix specified.\n"
-            == result.output
-        )
 
     def test_change_hook_ids(self, requests_mock, cli_runner):
         requests_mock.get(


### PR DESCRIPTION
Closes https://github.com/rossumai/rossum/issues/27

This MR removes the necessity to pass `bounce_email` to create an inbox and adds the option to create an inbox while passing email instead of email prefix when using the python API client directly.