### PR TITLE
Allow uploading document by passing file as bytes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,7 +92,7 @@ def mock_organization_urls(request: FixtureRequest, requests_mock):
 @pytest.fixture
 def mock_file(tmp_path):
     invoice_sample = tmp_path / "empty_file.pdf"
-    invoice_sample.write_bytes(_EMPTY_PDF_FILE)
+    invoice_sample.write_bytes(EMPTY_PDF_FILE)
     yield invoice_sample
 
 
@@ -129,7 +129,7 @@ Content-Type: {request.headers['Content-Type']}
     }
 
 
-_EMPTY_PDF_FILE = b"""%PDF-1.3
+EMPTY_PDF_FILE = b"""%PDF-1.3
 1 0 obj
 <<
 /Type /Pages

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -3,7 +3,9 @@ from functools import partial
 import pytest
 
 from rossum.lib.api_client import RossumClient, RossumException
-from tests.conftest import INBOXES_URL, match_uploaded_json, QUEUES_URL
+from tests.conftest import INBOXES_URL, match_uploaded_json, QUEUES_URL, EMPTY_PDF_FILE
+
+QUEUE_ID = 600500
 
 
 @pytest.mark.usefixtures("rossum_credentials")
@@ -71,4 +73,32 @@ class TestRossumClient:
         with pytest.raises(RossumException):
             self.rossum_client.create_inbox(
                 name="My Email", email_prefix=None, bounce_email=None, queue_url=queue_url, email=""
+            )
+
+    def test_upload_document_as_bytes_success(self, requests_mock):
+        requests_mock.post(f"{QUEUES_URL}/{QUEUE_ID}/upload", json={"id": 100200}, status_code=201)
+        self.rossum_client.upload_document(
+            id_=QUEUE_ID,
+            filename_overwrite="My Invoice.pdf",
+            values={"upload:organization_unit": "Sales"},
+            metadata={"SAP_ID": 123456},
+            file_bytes=EMPTY_PDF_FILE,
+        )
+        assert requests_mock.called
+
+    def test_upload_document_filename_not_passed(self):
+        with pytest.raises(RossumException):
+            self.rossum_client.upload_document(
+                id_=QUEUE_ID,
+                values={"upload:organization_unit": "Sales"},
+                metadata={"SAP_ID": 123456},
+                file_bytes=EMPTY_PDF_FILE,
+            )
+
+    def test_upload_document_files_not_passed(self):
+        with pytest.raises(RossumException):
+            self.rossum_client.upload_document(
+                id_=QUEUE_ID,
+                values={"upload:organization_unit": "Sales"},
+                metadata={"SAP_ID": 123456},
             )


### PR DESCRIPTION
This MR allows users to pass documents as bytes to Rossum, not only by passing file URL.