### PR TITLE
Add RossumClient.get_annotations method.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,6 @@ repos:
       - id: bandit
         args: [-lll]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.770
+    rev: v0.780
     hooks:
       - id: mypy

--- a/rossum/helpers/search_content.py
+++ b/rossum/helpers/search_content.py
@@ -22,9 +22,7 @@ def find_line_items_column(content: list, schema_id: str) -> list:
 
 
 def find_line_items_rows(content: list, schema_id: str) -> Optional[list]:
-    return jmespath.search(
-        f"[].children[?schema_id=='{schema_id}'][] | [0] | children[]", content
-    )
+    return jmespath.search(f"[].children[?schema_id=='{schema_id}'][] | [0] | children[]", content)
 
 
 def find_multivalue_parent(content: list, schema_id: str) -> Optional[dict]:

--- a/rossum/lib/api_client.py
+++ b/rossum/lib/api_client.py
@@ -439,6 +439,21 @@ class RossumClient(APIClient):
             raise RossumException("Annotation ID wasn't specified.")
         return get_json(self.get(f"{ANNOTATIONS}/{id_}"))
 
+    def get_annotations(
+        self,
+        *,
+        queue: Optional[int] = None,
+        status: Optional[Iterable[str]] = None,
+        sideloads: Optional[Iterable[Union[Sideload, str]]] = None,
+    ):
+        query = {}
+        if queue is not None:
+            query["queue"] = str(queue)
+        if status:
+            query["status"] = ",".join(status)
+        annotations, _ = self.get_paginated(ANNOTATIONS, query=query, sideloads=sideloads)
+        return annotations
+
     def poll_annotation(
         self, annotation: int, check_success: Callable, max_retries=120, sleep_secs=5
     ) -> dict:

--- a/rossum/lib/api_client.py
+++ b/rossum/lib/api_client.py
@@ -18,6 +18,7 @@ from tenacity import (
     retry_if_exception_type,
 )
 
+from .sideloading import to_sideloads, Sideload
 from rossum import __version__, CTX_PROFILE, CTX_DEFAULT_PROFILE
 from rossum.configure import get_credential
 from . import (
@@ -229,30 +230,63 @@ class APIClient(AbstractContextManager):
         query: Optional[Dict[str, Any]] = None,
         *,
         key: str = "results",
+        sideloads: Optional[Iterable[Union[Sideload, str]]] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
+        if query is None:
+            query = {}
+
+        sideloads = to_sideloads(sideloads)
+
+        if sideloads:
+            if "sideload" in query:
+                raise RossumException("sideloading cannot be specified both in query and sideloads")
+            query = query.copy()
+            for sideload in sideloads:
+                sideload.setup_query(query)
+
         response = self.get(path, query)
         response_dict = response.json()
 
-        res = response_dict[key]
+        res = response_dict
         next_page = response_dict["pagination"]["next"]
 
         while next_page:
             response = self.get_url(next_page)
             response_dict = response.json()
 
-            res.extend(response_dict[key])
+            for k, v in response_dict.items():
+                if k != "pagination":
+                    res.setdefault(k, []).extend(v)
             next_page = response_dict["pagination"]["next"]
 
-        return res, response_dict["pagination"]["total"]
+        if sideloads:
+            self._resolve_sideloads(res, sideloads)
+
+        return res[key], response_dict["pagination"]["total"]
 
     def _sideload(
         self, objects: List[dict], sideloads: Optional[Iterable[APIObject]] = None
     ) -> List[dict]:
+        response = {"results": objects}
         for sideload in sideloads or []:
             sideloaded, _ = self.get_paginated(sideload)
-            sideloaded_dicts = {
-                sideloaded_dict["url"]: sideloaded_dict for sideloaded_dict in sideloaded
-            }
+            response[sideload.plural] = sideloaded
+        if sideloads:
+            self._resolve_sideloads(response, to_sideloads(sideloads))
+        return response["results"]
+
+    def _resolve_sideloads(self, response: dict, sideloads: Iterable[Sideload]) -> None:
+        """
+        Resolve the dependency injections of sideloaded objects to corresponding
+        results objects in the `response`.
+
+        :param response Response object as returned from Rossum app for any
+        paginated GET-like request.
+        :param sideloads Optional list of object types to resolve dependency
+        injection for.
+        """
+        for sideload in sideloads or []:
+            sideloaded_dicts = sideload.get_mapping(response.get(sideload.plural, []))
 
             def inject_sideloaded(obj: dict) -> dict:
                 try:
@@ -267,8 +301,8 @@ class APIClient(AbstractContextManager):
                     obj[sideload.singular] = sideloaded_dicts.get(url, {})
                 return obj
 
-            objects = [inject_sideloaded(o) for o in objects]
-        return objects
+            for obj in response["results"]:
+                inject_sideloaded(obj)
 
     @property
     def _authentication(self) -> dict:

--- a/rossum/lib/sideloading.py
+++ b/rossum/lib/sideloading.py
@@ -1,0 +1,78 @@
+from dataclasses import dataclass, replace
+from typing import Dict, Iterable, List, Optional, Tuple, Union
+from . import APIObject
+
+
+@dataclass(frozen=True)
+class Sideload:
+    NOT_SET = "NOT_SET"
+
+    plural: str
+    singular: str = NOT_SET
+
+    def __post_init__(self) -> None:
+        if self.singular is self.NOT_SET:
+            # https://docs.python.org/3/library/dataclasses.html#frozen-instances
+            object.__setattr__(self, "singular", self.plural.rstrip("s"))
+
+    @staticmethod
+    def _parse_query_array(array: str) -> List[str]:
+        return [item.strip() for item in array.split(",") if item.strip()]
+
+    def setup_query(self, query: dict) -> None:
+        query_sideloads = self._parse_query_array(query.get("sideload", ""))
+        if str(self) not in query_sideloads:
+            query_sideloads.append(str(self))
+        query["sideload"] = ",".join(query_sideloads)
+
+    @staticmethod
+    def get_mapping(objects: List[dict]) -> dict:
+        return {obj["url"]: obj for obj in objects}
+
+    def __str__(self) -> str:
+        return self.plural
+
+
+@dataclass(frozen=True)
+class Content(Sideload):
+    schema_ids: Union[Tuple[str], Tuple[()]] = ()
+
+    def setup_query(self, query: dict) -> None:
+        if not self.schema_ids:
+            # Content sideloading without any schema ID has no effect."
+            return
+        super().setup_query(query)
+        query_schema_ids = self._parse_query_array(query.get("content.schema_id", ""))
+        for schema_id in self.schema_ids:
+            if schema_id not in query_schema_ids:
+                query_schema_ids.append(schema_id)
+        query["content.schema_id"] = ",".join(query_schema_ids)
+
+    @staticmethod
+    def get_mapping(objects: List[dict]) -> dict:
+        mapping: Dict[str, List[dict]] = {}
+        for obj in objects:
+            mapping.setdefault(obj["url"].rsplit("/", 1)[0], []).append(obj)
+        return mapping
+
+    def __call__(self, *schema_ids: Iterable[str]) -> "Content":
+        return replace(self, schema_ids=schema_ids)
+
+
+def to_sideloads(
+    sideloads: Optional[Iterable[Union[APIObject, Sideload, str]]]
+) -> Iterable[Sideload]:
+    def cast(sideload: Union[APIObject, Sideload, str]) -> Sideload:
+        if isinstance(sideload, APIObject):
+            return Sideload(sideload.plural, sideload.singular)
+        elif isinstance(sideload, Sideload):
+            return sideload
+        elif isinstance(sideload, str):
+            return Sideload(sideload)
+        else:
+            raise TypeError
+
+    return [cast(sideload) for sideload in sideloads or []]
+
+
+CONTENT = Content("content")

--- a/rossum/workspace.py
+++ b/rossum/workspace.py
@@ -56,8 +56,9 @@ def delete_command(ctx: click.Context, id_: int) -> None:
         for queue in queues:
             res, _ = rossum.get_paginated(
                 "annotations",
-                {"page_size": 50, "queue": queue["id"], "sideload": "documents"},
+                {"page_size": 50, "queue": queue["id"]},
                 key="documents",
+                sideloads=["documents"],
             )
             documents.update({d["id"]: d["url"] for d in res})
 

--- a/tests/helpers/test_search_content.py
+++ b/tests/helpers/test_search_content.py
@@ -3,7 +3,8 @@ from rossum.helpers.search_content import (
     find_all_line_items_datapoints,
     find_single_datapoint,
     find_multivalue_parent,
-    find_children_of_simple_multivalue, find_line_items_rows,
+    find_children_of_simple_multivalue,
+    find_line_items_rows,
 )
 
 ACCOUNT_NUMBER_NAME = "account_num"

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -21,11 +21,7 @@ class TestRossumClient:
             active=True,
             events=["annotation_content.initialize", "annotation_content.user_update"],
             sideload=[],
-            config={
-                "url": "httpmock:/adfa.asdf",
-                "secret": "sdf",
-                "insecure_ssl": False,
-            },
+            config={"url": "httpmock:/adfa.asdf", "secret": "sdf", "insecure_ssl": False},
             token_owner="httpmock://tokenowner.url",
             extension_source="rossum_store",
         )

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -134,3 +134,10 @@ class TestRossumClient:
                 values={"upload:organization_unit": "Sales"},
                 metadata={"SAP_ID": 123456},
             )
+
+    def test_get_paginated_with_ambiguous_sideloading(self):
+        with pytest.raises(RossumException) as ex:
+            self.rossum_client.get_paginated(
+                QUEUES_URL, query={"sideload": "workspaces"}, sideloads=["workspaces"]
+            )
+        assert "sideloading cannot be specified both in query and sideloads" == str(ex.value)

--- a/tests/test_sideloading.py
+++ b/tests/test_sideloading.py
@@ -1,0 +1,110 @@
+import pytest
+from typing import Any, Iterable, List, Union
+
+from rossum.lib import APIObject, ANNOTATIONS
+from rossum.lib.sideloading import CONTENT, Sideload, to_sideloads
+
+from tests.conftest import ANNOTATIONS_URL, DOCUMENTS_URL
+
+
+@pytest.mark.parametrize(
+    "sideloads, raises, expected",
+    [
+        (
+            ["documents", CONTENT("document_id"), ANNOTATIONS],
+            False,
+            [Sideload("documents"), CONTENT("document_id"), Sideload("annotations")],
+        ),
+        (["documents", 5], True, []),
+        (None, False, []),
+    ],
+)
+def test_to_sideloads(
+    sideloads: Iterable[Any], raises: bool, expected: Iterable[Union[APIObject, Sideload, str]]
+) -> None:
+    if raises:
+        with pytest.raises(TypeError):
+            to_sideloads(sideloads)
+    else:
+        assert to_sideloads(sideloads) == expected
+
+
+@pytest.mark.parametrize(
+    "sideload, query, expected",
+    [
+        (Sideload("documents"), {}, {"sideload": "documents"}),
+        (Sideload("documents"), {"sideload": "modifiers"}, {"sideload": "modifiers,documents"}),
+        (CONTENT, {}, {}),
+        (CONTENT("document_id"), {}, {"sideload": "content", "content.schema_id": "document_id"}),
+        (
+            CONTENT("order_id"),
+            {"sideload": "content", "content.schema_id": "document_id"},
+            {"sideload": "content", "content.schema_id": "document_id,order_id"},
+        ),
+        (
+            CONTENT("order_id"),
+            {"sideload": "documents,content", "content.schema_id": "document_id"},
+            {"sideload": "documents,content", "content.schema_id": "document_id,order_id"},
+        ),
+    ],
+)
+def test_setup_sideload_query(sideload: Sideload, query: dict, expected: dict) -> None:
+    sideload.setup_query(query)
+    assert query == expected
+
+
+@pytest.mark.parametrize(
+    "sideload, objects, expected",
+    [
+        (
+            Sideload("documents"),
+            [
+                {"url": f"{DOCUMENTS_URL}/1", "name": "Document #1"},
+                {"url": f"{DOCUMENTS_URL}/2", "name": "Document #2"},
+                {"url": f"{DOCUMENTS_URL}/2", "name": "Document #2: Last wins!"},
+            ],
+            {
+                f"{DOCUMENTS_URL}/1": {"url": f"{DOCUMENTS_URL}/1", "name": "Document #1"},
+                f"{DOCUMENTS_URL}/2": {
+                    "url": f"{DOCUMENTS_URL}/2",
+                    "name": "Document #2: Last wins!",
+                },
+            },
+        ),
+        (
+            CONTENT("order_id"),
+            [
+                {
+                    "url": f"{ANNOTATIONS_URL}/1/content/1",
+                    "schema_id": "order_id",
+                    "value": "PO#ABC",
+                },
+                {"url": f"{ANNOTATIONS_URL}/1/content/2", "schema_id": "order_id", "value": "123"},
+                {"url": f"{ANNOTATIONS_URL}/2/content/3", "schema_id": "order_id", "value": "DEF"},
+            ],
+            {
+                f"{ANNOTATIONS_URL}/1/content": [
+                    {
+                        "url": f"{ANNOTATIONS_URL}/1/content/1",
+                        "schema_id": "order_id",
+                        "value": "PO#ABC",
+                    },
+                    {
+                        "url": f"{ANNOTATIONS_URL}/1/content/2",
+                        "schema_id": "order_id",
+                        "value": "123",
+                    },
+                ],
+                f"{ANNOTATIONS_URL}/2/content": [
+                    {
+                        "url": f"{ANNOTATIONS_URL}/2/content/3",
+                        "schema_id": "order_id",
+                        "value": "DEF",
+                    }
+                ],
+            },
+        ),
+    ],
+)
+def test_get_sideload_mapping(sideload: Sideload, objects: List[dict], expected: dict) -> None:
+    assert sideload.get_mapping(objects) == expected

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -101,6 +101,10 @@ class TestDelete:
             request_headers={"Authorization": f"Token {TOKEN}"},
             json={
                 "pagination": {"next": None, "total": 1},
+                "results": [
+                    {"id": i, "url": fr"{ANNOTATIONS_URL}/{i}", "document": fr"{DOCUMENTS_URL}/{i}"}
+                    for i in range(n_documents)
+                ],
                 "documents": [
                     {"id": i, "url": fr"{DOCUMENTS_URL}/{i}"} for i in range(n_documents)
                 ],


### PR DESCRIPTION
Add an extra method to `RossumClient`, which allows to get annotation (meta)data. It allows to filter annotations based on queue and different states (status-es). To allow effective sideloading of, for example, corresponding documents' (meta)data, sideloading functionality was refactored a bit as well (`APIClient.get_paginated` now supports sideloading).