### PR TITLE
Ensure compatibility with click 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,11 +62,11 @@ jobs:
           tags: true
 
 
+# Hotfix: setuptools is capped at version 59, as newer versions seem to have issues with importlib_metadata in python 3.7.
+# See e.g. https://app.travis-ci.com/github/rossumai/rossum/jobs/560023987
 install:
-  - pip install tox-travis setuptools --upgrade
+  - pip install tox-travis "setuptools<60" --upgrade
 
 # command to run tests
 script:
   - tox -c ${TOXCFG}
-
-

--- a/rossum/option.py
+++ b/rossum/option.py
@@ -135,8 +135,17 @@ test = click.option(
 
 
 class OptionRequiredIf(click.Option):
-    def full_process_value(self, ctx, value):
+    def full_process_value(self, ctx, value):  # pragma: no cover
+        # full_process_value is called in Click < 8.0
         value = super(OptionRequiredIf, self).full_process_value(ctx, value)
+        return self._process_value(ctx, value)
+
+    def process_value(self, ctx, value):
+        # process_value is called in Click >= 8.0
+        value = super(OptionRequiredIf, self).process_value(ctx, value)
+        return self._process_value(ctx, value)
+
+    def _process_value(self, ctx, value):
         option = self.human_readable_name
 
         required_params = {

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,13 @@ setup(
     ],
     python_requires=">=3.6",
     setup_requires=["pytest-runner"],
-    tests_require=["pytest", "pytest-cov", "requests_mock", "pytest-click"],
+    tests_require=[
+        "pytest",
+        "pytest-cov",
+        "requests_mock",
+        "pytest-click",
+        'tomli<2.0;python_version<"3.7"',
+    ],
     zip_safe=False,
     entry_points={"console_scripts": ["rossum = rossum.main:entry_point"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     packages=find_packages(exclude=("tests*",)),
     install_requires=[
         "pandas",
-        "click<=7.1.2",
+        "click<8.1.0",
         "click-shell",
         'xlrd > 1.2.0;python_version>"3.6"',
         'xlrd==1.2.0;python_version=="3.6"',

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from traceback import print_tb, format_tb
 from typing import List
 
+import click
 import pytest
 
 from rossum.hook import list_command, change_command, delete_command, create_command
@@ -32,6 +33,7 @@ TOKEN_OWNER_ID = 12345
 TOKEN_OWNER_URL = f"{USERS_URL}/{TOKEN_OWNER_ID}"
 RUN_AFTER_HOOK_ID = 999
 RUN_AFTER_URLS = [f"{HOOKS_URL}/{RUN_AFTER_HOOK_ID}"]
+EXTRA_SPACE_IN_CLICK7 = " " if int(click.__version__.split(".")[0]) < 8 else ""
 
 
 def get_params(hook_type, value):
@@ -44,7 +46,7 @@ def get_params(hook_type, value):
             },
             "expected_result": (f", {CONFIG_URL}, {CONFIG_SECRET}"),
             "illegal_usage_result": "--config_runtime cannot be used for the hook type webhook",
-            "missing_option_result": "'--config-insecure-ssl'.  Required if hook type is webhook",
+            "missing_option_result": f"'--config-insecure-ssl'. {EXTRA_SPACE_IN_CLICK7}Required if hook type is webhook",
             "expected_table_without_secret": f"""\
   id  name           events                              queues  active    sideload    url                             insecure_ssl
 ----  -------------  --------------------------------  --------  --------  ----------  ------------------------------  --------------
@@ -60,7 +62,7 @@ def get_params(hook_type, value):
             "config": {"code": Path(CONFIG_CODE).read_text(), "runtime": CONFIG_RUNTIME},
             "expected_result": "",
             "illegal_usage_result": "--config_url cannot be used for the hook type function",
-            "missing_option_result": "'--config-runtime'.  Required if hook type is function",
+            "missing_option_result": f"'--config-runtime'. {EXTRA_SPACE_IN_CLICK7}Required if hook type is function",
             "expected_table": f"""\
   id  name           events                              queues  active    sideload
 ----  -------------  --------------------------------  --------  --------  ----------


### PR DESCRIPTION
See https://click.palletsprojects.com/en/8.0.x/api/#parameters for the change in API:
> Changed in version 8.0: process_value validates required parameters and bounded nargs, and invokes the parameter callback before returning the value. This allows the callback to validate prompts. full_process_value is removed.